### PR TITLE
Make utility functions top-level

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Usage
 
 Creating a random access sink/source is done similarly to Okio's `source()`/`sink()` API:
 ```kotlin
-import com.github.armay.okrandomaccess.OkRandomAccess.buffer
-import com.github.armay.okrandomaccess.OkRandomAccess.randomAccessSink
-import com.github.armay.okrandomaccess.OkRandomAccess.randomAccessSource
+import com.github.armay.okrandomaccess.buffer
+import com.github.armay.okrandomaccess.randomAccessSink
+import com.github.armay.okrandomaccess.randomAccessSource
 
 /* Other imports & code */
 

--- a/lib/src/main/kotlin/com/github/armay/okrandomaccess/OkRandomAccess.kt
+++ b/lib/src/main/kotlin/com/github/armay/okrandomaccess/OkRandomAccess.kt
@@ -3,26 +3,21 @@ package com.github.armay.okrandomaccess
 import java.nio.file.Path
 
 /**
- * This object provides convenient extensions for creation of random access sinks & sources.
+ * Creates a new random access file sink from a given path.
  */
-object OkRandomAccess {
-    /**
-     * Creates a new random access file sink from a given path.
-     */
-    fun Path.randomAccessSink(): RandomAccessSink = RandomAccessFileSink(this)
+fun Path.randomAccessSink(): RandomAccessSink = RandomAccessFileSink(this)
 
-    /**
-     * Creates a new random access file source from a given path.
-     */
-    fun Path.randomAccessSource(): RandomAccessSource = RandomAccessFileSource(this)
+/**
+ * Creates a new random access file source from a given path.
+ */
+fun Path.randomAccessSource(): RandomAccessSource = RandomAccessFileSource(this)
 
-    /**
-     * Creates a new buffered random access sink from a given random access sink.
-     */
-    fun RandomAccessSink.buffer() = RandomAccessBufferedSink(this)
+/**
+ * Creates a new buffered random access sink from a given random access sink.
+ */
+fun RandomAccessSink.buffer() = RandomAccessBufferedSink(this)
 
-    /**
-     * Creates a new buffered random access source from a given random access source.
-     */
-    fun RandomAccessSource.buffer() = RandomAccessBufferedSource(this)
-}
+/**
+ * Creates a new buffered random access source from a given random access source.
+ */
+fun RandomAccessSource.buffer() = RandomAccessBufferedSource(this)

--- a/lib/src/test/kotlin/com/github/armay/okrandomaccess/OkRandomAccessTest.kt
+++ b/lib/src/test/kotlin/com/github/armay/okrandomaccess/OkRandomAccessTest.kt
@@ -1,8 +1,6 @@
 package com.github.armay.okrandomaccess
 
-import com.github.armay.okrandomaccess.OkRandomAccess.buffer
-import com.github.armay.okrandomaccess.OkRandomAccess.randomAccessSink
-import com.github.armay.okrandomaccess.OkRandomAccess.randomAccessSource
+import com.github.armay.okrandomaccess.buffer
 import com.google.common.jimfs.Configuration.unix
 import com.google.common.jimfs.Jimfs.newFileSystem
 import okio.buffer


### PR DESCRIPTION
Replace `OkRandomAccess` object with top-level functions in order to make imports in style of Okio, like
```kotlin
import com.github.armay.okrandomaccess.buffer
```
instead of 
```kotlin
import com.github.armay.okrandomaccess.OkRandomAccess.buffer
```