### PR TITLE
Update Gradle & Kotlin versions. Change version to 0.1.0

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -1,9 +1,9 @@
 group = "com.github.armay"
-version = "0.0.2"
+version = "0.1.0"
 
 plugins {
-    val dokkaVersion = "1.4.30"
-    val kotlinVersion = "1.4.32"
+    val dokkaVersion = "1.4.32"
+    val kotlinVersion = "1.5.0"
     kotlin("jvm") version kotlinVersion
     id("org.jetbrains.dokka") version dokkaVersion
     `java-library`

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,6 +4,5 @@ include("lib")
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
-        jcenter()
     }
 }


### PR DESCRIPTION
Version 0.1.0
- Gradle version changed to 7.0
- Kotlin version changed to 1.5.0
- Dokka version changed to 1.4.32
- JCenter removed from repositories